### PR TITLE
Add app and tags as params on hash to graylog

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ The logging framework uses the [little-plugger](https://github.com/twp/little-pl
  
          require 'logging'
          Logging.init
-         graylog_appenders = Logging.appenders.graylog 'graylog-server'
+         graylog_appenders = Logging.appenders.graylog 'graylog-server',
                                     {
                                       server: 'localhost',
-                                      level : 'DEBUG'
+                                      level : 'DEBUG',
                                       port: '12201'
                                     }
         logger = Logging.logger['example_logger']
         logger.add_appenders \
-          graylog_appenders
+          graylog_appenders,
           Logging.appenders.file('example.log')
           
        logger.info "Hello World"
@@ -36,16 +36,20 @@ The logging framework uses the [little-plugger](https://github.com/twp/little-pl
 
 Please check [gelf-rb](https://github.com/graylog-labs/gelf-rb) for details
   
-  name     :          'A name for the graylog logger'
+  name     :      'A name for the graylog logger'
   
-  options  :       'Some optional params'
-  
+  options  :      'Some optional params'
+
   * server :      The address of the graylog server, default would be localhost
   
   * level  :      The logging level, Default would be 'DEBUG'
 
   * facility:     Default would be 'gelf-rb'
   
-  * host     The default value is  hostname of server from which rails logs are logged. You could override by passing host.
+  * host          The default value is  hostname of server from which rails logs are logged. You could override by passing host.
+
+  * app :         The name of the application, default would be logger
+
+  * tags :        Optional tags to filter on graylog
   
 #

--- a/lib/logging/appenders/graylog.rb
+++ b/lib/logging/appenders/graylog.rb
@@ -27,11 +27,13 @@ module Logging
         @server = opts.fetch(:server, '127.0.0.1')
         @port = opts.fetch(:port, 12201)
         @max_chunk_size = opts.fetch(:max_chunk_size, 'WAN')
-        hash = {}
-        hash['host'] = opts.fetch(:host, Socket.gethostname)
-        hash['facility'] = opts.fetch(:facility, 'gelf-rb')
-        hash['level'] = LEVELS_MAP[opts.fetch(:level, 'DEBUG')]
-        @gelf_notifier = GELF::Notifier.new(@server, @port, @max_chunk_size, hash)
+        @hash = {}
+        @hash['app'] = opts.fetch(:app, nil)
+        @hash['facility'] = opts.fetch(:facility, 'gelf-rb')
+        @hash['host'] = opts.fetch(:host, Socket.gethostname)
+        @hash['level'] = LEVELS_MAP[opts.fetch(:level, 'DEBUG')]
+        @hash['tags'] = opts.fetch(:tags, nil)
+        @gelf_notifier = GELF::Notifier.new(@server, @port, @max_chunk_size, @hash)
       end
 
       private

--- a/logging-graylog.gemspec
+++ b/logging-graylog.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logging-graylog'
-  s.version     = '1.1.1'
+  s.version     = '1.1.2'
   s.date        = '2017-08-27'
   s.summary     = "logging-graylog!"
   s.description = "A plugin for logging gem to forward to graylog "

--- a/test/test_graylog.rb
+++ b/test/test_graylog.rb
@@ -24,6 +24,13 @@ module TestLogging
         assert_equal(12207, appender.instance_variable_get('@port'))
         assert_equal('LAN', appender.instance_variable_get('@max_chunk_size'))
       end
+
+      def test_options
+        appender = Logging.appenders.graylog('graylog', {app: "test-graylog", tags: "LOGGING,RAILS,TEST_UNIT"})
+        assert_equal('127.0.0.1', appender.instance_variable_get('@server'))
+        assert_equal('test-graylog', appender.instance_variable_get('@hash')["app"])
+        assert_equal('LOGGING,RAILS,TEST_UNIT', appender.instance_variable_get('@hash')["tags"])
+      end
     end
   end
 end


### PR DESCRIPTION
## Added:
 - `app` and `tags` as optional params

## Fixed:
 - Correct example syntax
 - Readme with new params